### PR TITLE
Test Travis CI on 3.9-dv

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,8 @@ matrix:
                 - dist: bionic
                   python: "3.8-dev"
                   env:    MAINT_EXTRA=0
+                - python: "3.9-dev"
+                  env:    MAINT_EXTRA=0
 
 before_install:
         # http://docs.travis-ci.com/user/installing-dependencies/#Installing-Ubuntu-packages


### PR DESCRIPTION
These are only available in `collections.abc` from Python 3.9.

https://bugzilla.redhat.com/show_bug.cgi?id=1791769

Updated to only test on `3.9-dev`.